### PR TITLE
Adds support for OPS

### DIFF
--- a/RORPlugin.php
+++ b/RORPlugin.php
@@ -38,10 +38,9 @@ class RORPlugin extends GenericPlugin {
 					'validation' => ['nullable']
 				];
 			});
-			# Article
+			# Submission
 			HookRegistry::register('ArticleHandler::view', array(&$this, 'submissionView'));
-			//HookRegistry::register('PreprintHandler::view', array(&$this, 'submissionView'));
-
+			HookRegistry::register('PreprintHandler::view', array(&$this, 'submissionView'));
 
 		}
 		return $success;


### PR DESCRIPTION
We're sending this contribution so this plugin can support functioning in OPS too.

We already sent a [PR to the OPS repository](https://github.com/pkp/ops/pull/204) adding the lines required to display the ROR icon link.