### PR TITLE
specify v1 api url

### DIFF
--- a/templates/affiliation.tpl
+++ b/templates/affiliation.tpl
@@ -17,7 +17,7 @@
 			tagLimit: 1,
 			tagSource: function (search, r) {ldelim}
 				$.ajax({ldelim}
-					url: 'https://api.ror.org/organizations',
+					url: 'https://api.ror.org/v1/organizations',
 					dataType: 'json',
 					cache: true,
 					data: {ldelim}


### PR DESCRIPTION
See https://ror.readme.io/changelog/2025-07-30-default-response-to-api-requests-is-now-version-2

[The v1 API will be sunset in December](https://ror.org/blog/2025-06-11-v1-sunset/), so an update to v2 will later be needed, but this fixes the issue for now until that can be updated.