### PR TITLE
Fixes problem that prevented creation of authors

### DIFF
--- a/RORPlugin.php
+++ b/RORPlugin.php
@@ -68,12 +68,10 @@ class RORPlugin extends GenericPlugin {
 				$author->setData('rorId', str_replace(['[', ']'], '', $matches[0]));
 				$affiliation = preg_replace($rorIDPattern, '', $value);
 				$author->setData('affiliation', $affiliation, $locale);
-			} else {
-				if ($locale == $publicationLocale) {
-					$currentAffiliation = $this->getCurrentAuthorAffiliation($author->getId(), $locale);
-					if ($currentAffiliation !== $value) {
-						$author->setData('rorId', null);
-					}
+			} elseif (!is_null($author->getId()) && $locale == $publicationLocale) {
+				$currentAffiliation = $this->getCurrentAuthorAffiliation($author->getId(), $locale);
+				if ($currentAffiliation !== $value) {
+					$author->setData('rorId', null);
 				}
 			}
 		}


### PR DESCRIPTION
We noticed that the previous blocked the creation of authors without an affiliation set. In these cases, trying to retrieve the author from the database resulted in a error, which failed the author creation.

Now, the code only tries to unset the `rorId` if the author already exists (i.e.: if it has an ID).