### PR TITLE
Fix ROR ID removal when resaving an unchanged affiliation (3.3.0)

### DIFF
--- a/RORPlugin.php
+++ b/RORPlugin.php
@@ -70,7 +70,7 @@ class RORPlugin extends GenericPlugin {
 				$author->setData('affiliation', $affiliation, $locale);
 			} elseif (!is_null($author->getId()) && $locale == $publicationLocale) {
 				$currentAffiliation = $this->getCurrentAuthorAffiliation($author->getId(), $locale);
-				if ($currentAffiliation !== $value) {
+				if (trim($currentAffiliation) !== trim($value)) {
 					$author->setData('rorId', null);
 				}
 			}


### PR DESCRIPTION
When an author with a ROR organization is saved, removing the ROR URL from the affiliation may leave trailing whitespace. After reopening the form, the affiliation is trimmed by the interface.
Saving the author again without making any visible changes causes the stored and submitted affiliations to differ only by whitespace. The plugin treats this as an affiliation change and incorrectly clears the author's `rorId`.

OJS 3.3.0

<img width="1488" height="768" alt="ror_id" src="https://github.com/user-attachments/assets/c2559834-2854-4770-98b8-c4cee23551b2" />
